### PR TITLE
DEV[1.13] bugfix: state setter for text

### DIFF
--- a/src/components/TextBlock.js
+++ b/src/components/TextBlock.js
@@ -28,7 +28,7 @@ export default function TextBlock() {
       <textarea
         ref={contentRef}
         value={content}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => setContent(e.target.value)}
         placeholder = "Start writing your notes here..."
         className="w-full text-xl p-2 outline-none resize-none bg-transparent text-black placeholder-gray-400 leading-relaxed"
         rows={5}


### PR DESCRIPTION
The textarea onChange event was using the wrong setter for the content's state. Fixed by changing from
`setText` to `setContent`. Once merged, user can now type on the content text area.