### PR TITLE
[DEV 1.7] Tone selection list

### DIFF
--- a/src/components/StartButton.js
+++ b/src/components/StartButton.js
@@ -1,7 +1,42 @@
-export default function StartButton({onClick, isConnected}){
+import { useState } from "react";
+
+export default function StartButton({clickHandler, isConnected}){
+    const [tone, setTone] = useState("Concise");
+
     return (
-        <button onClick={onClick} className={`w-24 h-24 ${isConnected? `bg-gray-500 hover:bg-gray-400` : `bg-gray-400 hover:bg-gray-500`}  text-white rounded-full shadow-lg  flex items-center justify-center`}>
-            <img src="mic.png" alt="Mic" width="60" height="60"/>
-        </button>
+        <div className="relative flex items-center justify-center">
+            <button
+                onClick={() => clickHandler(tone)}
+                className={`w-24 h-24 ${isConnected? `bg-gray-500 hover:bg-gray-400` : `bg-gray-400 hover:bg-gray-500`} mb-2 text-white rounded-full shadow-lg  flex items-center justify-center`}
+                >
+                    <img src="mic.png" alt="Mic" width="60" height="60"/>
+            </button>
+            <div className="absolute top-full flex space-x-3">
+                <button
+                    onClick={() => setTone("Concise")}
+                    className={`text-black p-1 bg-gray-200 hover:bg-gray-400 rounded ${tone === "Concise" ? "bg-gray-400 text-white" : ""}`}
+                    >
+                        Concise
+                </button>
+                <button
+                    onClick={() => setTone("Professional")}
+                    className={`text-black p-1 bg-gray-200 hover:bg-gray-400 rounded ${tone === "Professional" ? "bg-gray-400 text-white" : ""}`}
+                    >
+                        Professional
+                </button>
+                <button
+                    onClick={() => setTone("Technical")}
+                    className={`text-black p-1 bg-gray-200 hover:bg-gray-400 rounded ${tone === "Technical" ? "bg-gray-400 text-white" : ""}`}
+                    >
+                        Technical
+                </button>
+                <button
+                    onClick={() => setTone("Friendly")}
+                    className={`text-black p-1 bg-gray-200 hover:bg-gray-400 rounded ${tone === "Friendly" ? "bg-gray-400 text-white" : ""}`}
+                    >
+                        Friendly
+                </button>
+            </div>
+        </div>
     );
 }

--- a/src/components/StartButton.js
+++ b/src/components/StartButton.js
@@ -7,7 +7,7 @@ export default function StartButton({clickHandler, isConnected}){
         <div className="relative flex items-center justify-center">
             <button
                 onClick={() => clickHandler(tone)}
-                className={`w-24 h-24 ${isConnected? `bg-gray-500 hover:bg-gray-400` : `bg-gray-400 hover:bg-gray-500`} mb-2 text-white rounded-full shadow-lg  flex items-center justify-center`}
+                className={`w-24 h-24 ${isConnected? `bg-gray-500 hover:bg-gray-400` : `bg-gray-400 hover:bg-gray-500`} mb-2 text-white rounded-full shadow-lg flex items-center justify-center`}
                 >
                     <img src="mic.png" alt="Mic" width="60" height="60"/>
             </button>

--- a/src/components/TextBlock.js
+++ b/src/components/TextBlock.js
@@ -116,7 +116,7 @@ export default function TextBlock({setFileTitle}) {
   }, [content]);
 
   // Handle WebSocket connection
-  const handleStartButtonClick = () => {
+  const handleStartButtonClick = (tone) => {
     if (isConnected) {
       // Close WebSocket connection
       if (wsRef.current) {
@@ -189,7 +189,7 @@ export default function TextBlock({setFileTitle}) {
         rows={5}
       />
       <div className="flex justify-center basis-0">
-        <StartButton onClick={handleStartButtonClick} isConnected={isConnected}/>
+        <StartButton clickHandler={handleStartButtonClick} isConnected={isConnected}/>
       </div>
     </div>
   );


### PR DESCRIPTION
Implemented a simple, static list of tone options that can be selected for our prompt templates. Additionally, renamed the `onClick` prop to `clickHandler`.

Screenshot:
![image](https://github.com/user-attachments/assets/ed125403-fa55-4180-b4a5-11c3581fb013)
