### PR TITLE
[DEV 2.0] shift speech recognition + transcription logic to websocket client

### DIFF
--- a/src/lib/SpeechRecognition.js
+++ b/src/lib/SpeechRecognition.js
@@ -1,0 +1,44 @@
+export const setUpRecognition = (wsRef) => {
+  let recognition; 
+
+  if (typeof window !== 'undefined') { // added this check as I would get window not defined error (probably has to do with SSR)
+    // Create a SpeechRecognition instance (using vendor prefixes for broader compatibility)
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    recognition = new SpeechRecognition();
+  
+    // Configure speech recognition
+    recognition.continuous = true;        // Keep recognition running continuously
+    recognition.interimResults = false;   // Send only final results if false, otherwise sends partial transcripts
+    recognition.lang = 'en-US';           // Set the language (adjust as needed)
+  
+    // Speech recognition handler
+    recognition.onresult = (event) => {
+  
+      let transcript = '';
+      for (let i = event.resultIndex; i < event.results.length; ++i) {
+        if (event.results[i].isFinal) {
+          transcript += event.results[i][0].transcript;
+        }
+      }
+      if (transcript) {
+        console.log("Transcribed speech:", transcript);
+  
+        // Send the transcribed speech to WebSocket server
+        if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+          wsRef.current.send(transcript);
+        }
+      }
+    };
+  
+    recognition.onerror = (event) => {
+      console.error("Speech recognition error:", event.error);
+    };
+  
+    recognition.onend = () => {
+      console.log("Speech recognition ended.");
+    };
+  }
+  return recognition;
+}
+
+export { setUpRecognition };

--- a/src/lib/SpeechRecognition.js
+++ b/src/lib/SpeechRecognition.js
@@ -41,4 +41,3 @@ export const setUpRecognition = (wsRef) => {
   return recognition;
 }
 
-export { setUpRecognition };


### PR DESCRIPTION
Before this commit, speech recognition was handled on the server side. This creates issues when interacting with the tool, as users will likely utilize the microphone on their client-side device for transcription. I hooked up the [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API) for the client-side speech transcription.


Note that this Web Speech API does not work on Safari. So we will have to revisit this essential feature for Safari support. Tested and works on Chrome.

Additionally, I trimmed some whitespace in the relevant files.